### PR TITLE
Consider user streamArraySize in bytes/flops calc.

### DIFF
--- a/src/RaiderSTREAM/RSOpts.cpp
+++ b/src/RaiderSTREAM/RSOpts.cpp
@@ -79,6 +79,7 @@ bool RSOpts::enableBenchmark(std::string benchName) {
 bool RSOpts::parseOpts(int argc, char **argv) {
   lArgc = argc;
   lArgv = argv;
+
   for (int i = 1; i < argc; i++) {
     std::string s(argv[i]);
 
@@ -157,65 +158,11 @@ bool RSOpts::parseOpts(int argc, char **argv) {
   }
 #endif
 
-  /* Populate BYTES, FLOPS arrays with given streamArraySize */
-  double newBytes[NUM_KERNELS] = {
-		// Original Kernels
-		static_cast<double>(2 * sizeof(double) * streamArraySize), // Copy
-		static_cast<double>(2 * sizeof(double) * streamArraySize), // Scale
-		static_cast<double>(3 * sizeof(double) * streamArraySize), // Add
-		static_cast<double>(3 * sizeof(double) * streamArraySize), // Triad
-		// Gather Kernels
-		static_cast<double>(((2 * sizeof(double)) + (1 * sizeof(ssize_t))) * streamArraySize), // GATHER Copy
-		static_cast<double>(((2 * sizeof(double)) + (1 * sizeof(ssize_t))) * streamArraySize), // GATHER Scale
-		static_cast<double>(((3 * sizeof(double)) + (2 * sizeof(ssize_t))) * streamArraySize), // GATHER Add
-		static_cast<double>(((3 * sizeof(double)) + (2 * sizeof(ssize_t))) * streamArraySize), // GATHER Triad
-		// Scatter Kernels
-		static_cast<double>(((2 * sizeof(double)) + (1 * sizeof(ssize_t))) * streamArraySize), // SCATTER Copy
-		static_cast<double>(((2 * sizeof(double)) + (1 * sizeof(ssize_t))) * streamArraySize), // SCATTER Scale
-		static_cast<double>(((3 * sizeof(double)) + (1 * sizeof(ssize_t))) * streamArraySize), // SCATTER Add
-		static_cast<double>(((3 * sizeof(double)) + (1 * sizeof(ssize_t))) * streamArraySize), // SCATTER Triad
-		// Scatter-Gather Kernels
-		static_cast<double>(((2 * sizeof(double)) + (2 * sizeof(ssize_t))) * streamArraySize), // SG Copy
-		static_cast<double>(((2 * sizeof(double)) + (2 * sizeof(ssize_t))) * streamArraySize), // SG Scale
-		static_cast<double>(((3 * sizeof(double)) + (3 * sizeof(ssize_t))) * streamArraySize), // SG Add
-		static_cast<double>(((3 * sizeof(double)) + (3 * sizeof(ssize_t))) * streamArraySize), // SG Triad
-		// Central Kernels
-		static_cast<double>(2 * sizeof(double) * streamArraySize), // Central Copy
-		static_cast<double>(2 * sizeof(double) * streamArraySize), // Central Scale
-		static_cast<double>(3 * sizeof(double) * streamArraySize), // Central Add
-		static_cast<double>(3 * sizeof(double) * streamArraySize), // Central Triad
-  };
-
-  double newFlops[NUM_KERNELS] = {
-		// Original Kernels
-		(double)0.0,                       // Copy
-		1.0 * streamArraySize,             // Scale
-		1.0 * streamArraySize,             // Add
-		2.0 * streamArraySize,             // Triad
-		// Gather Kernels
-		(double)0.0,                       // GATHER Copy
-		1.0 * streamArraySize,             // GATHER Scale
-		1.0 * streamArraySize,             // GATHER Add
-		2.0 * streamArraySize,             // GATHER Triad
-		// Scatter Kernels
-		(double)0.0,                       // SCATTER Copy
-		1.0 * streamArraySize,             // SCATTER Scale
-		1.0 * streamArraySize,             // SCATTER Add
-		2.0 * streamArraySize,             // SCATTER Triad
-		// Scatter-Gather Kernels
-		(double)0.0,                       // SG Copy
-		1.0 * streamArraySize,             // SG Scale
-		1.0 * streamArraySize,             // SG Add
-		2.0 * streamArraySize,             // SG Triad
-		// Central Kernels
-		(double)0.0,                       // CENTRAL Copy
-		1.0 * streamArraySize,             // CENTRAL Scale
-		1.0 * streamArraySize,             // CENTRAL Add
-		2.0 * streamArraySize,             // CENTRAL Triad
-  };
-
-  memcpy(BYTES, newBytes, sizeof(double) * NUM_KERNELS);
-  memcpy(FLOATOPS, newFlops, sizeof(double) * NUM_KERNELS);
+  /* Update BYTES, FLOATOPS arrays with given streamArraySize */
+  for(int i = 0; i < NUM_KERNELS; i++) {
+    BYTES[i] *= streamArraySize;
+    FLOATOPS[i] *= streamArraySize;
+  }
 
   return true; /* Options are valid */
 }

--- a/src/RaiderSTREAM/RSOpts.cpp
+++ b/src/RaiderSTREAM/RSOpts.cpp
@@ -157,6 +157,66 @@ bool RSOpts::parseOpts(int argc, char **argv) {
   }
 #endif
 
+  /* Populate BYTES, FLOPS arrays with given streamArraySize */
+  double newBytes[NUM_KERNELS] = {
+		// Original Kernels
+		static_cast<double>(2 * sizeof(double) * streamArraySize), // Copy
+		static_cast<double>(2 * sizeof(double) * streamArraySize), // Scale
+		static_cast<double>(3 * sizeof(double) * streamArraySize), // Add
+		static_cast<double>(3 * sizeof(double) * streamArraySize), // Triad
+		// Gather Kernels
+		static_cast<double>(((2 * sizeof(double)) + (1 * sizeof(ssize_t))) * streamArraySize), // GATHER Copy
+		static_cast<double>(((2 * sizeof(double)) + (1 * sizeof(ssize_t))) * streamArraySize), // GATHER Scale
+		static_cast<double>(((3 * sizeof(double)) + (2 * sizeof(ssize_t))) * streamArraySize), // GATHER Add
+		static_cast<double>(((3 * sizeof(double)) + (2 * sizeof(ssize_t))) * streamArraySize), // GATHER Triad
+		// Scatter Kernels
+		static_cast<double>(((2 * sizeof(double)) + (1 * sizeof(ssize_t))) * streamArraySize), // SCATTER Copy
+		static_cast<double>(((2 * sizeof(double)) + (1 * sizeof(ssize_t))) * streamArraySize), // SCATTER Scale
+		static_cast<double>(((3 * sizeof(double)) + (1 * sizeof(ssize_t))) * streamArraySize), // SCATTER Add
+		static_cast<double>(((3 * sizeof(double)) + (1 * sizeof(ssize_t))) * streamArraySize), // SCATTER Triad
+		// Scatter-Gather Kernels
+		static_cast<double>(((2 * sizeof(double)) + (2 * sizeof(ssize_t))) * streamArraySize), // SG Copy
+		static_cast<double>(((2 * sizeof(double)) + (2 * sizeof(ssize_t))) * streamArraySize), // SG Scale
+		static_cast<double>(((3 * sizeof(double)) + (3 * sizeof(ssize_t))) * streamArraySize), // SG Add
+		static_cast<double>(((3 * sizeof(double)) + (3 * sizeof(ssize_t))) * streamArraySize), // SG Triad
+		// Central Kernels
+		static_cast<double>(2 * sizeof(double) * streamArraySize), // Central Copy
+		static_cast<double>(2 * sizeof(double) * streamArraySize), // Central Scale
+		static_cast<double>(3 * sizeof(double) * streamArraySize), // Central Add
+		static_cast<double>(3 * sizeof(double) * streamArraySize), // Central Triad
+  };
+
+  double newFlops[NUM_KERNELS] = {
+		// Original Kernels
+		(double)0.0,                       // Copy
+		1.0 * streamArraySize,             // Scale
+		1.0 * streamArraySize,             // Add
+		2.0 * streamArraySize,             // Triad
+		// Gather Kernels
+		(double)0.0,                       // GATHER Copy
+		1.0 * streamArraySize,             // GATHER Scale
+		1.0 * streamArraySize,             // GATHER Add
+		2.0 * streamArraySize,             // GATHER Triad
+		// Scatter Kernels
+		(double)0.0,                       // SCATTER Copy
+		1.0 * streamArraySize,             // SCATTER Scale
+		1.0 * streamArraySize,             // SCATTER Add
+		2.0 * streamArraySize,             // SCATTER Triad
+		// Scatter-Gather Kernels
+		(double)0.0,                       // SG Copy
+		1.0 * streamArraySize,             // SG Scale
+		1.0 * streamArraySize,             // SG Add
+		2.0 * streamArraySize,             // SG Triad
+		// Central Kernels
+		(double)0.0,                       // CENTRAL Copy
+		1.0 * streamArraySize,             // CENTRAL Scale
+		1.0 * streamArraySize,             // CENTRAL Add
+		2.0 * streamArraySize,             // CENTRAL Triad
+  };
+
+  memcpy(BYTES, newBytes, sizeof(double) * NUM_KERNELS);
+  memcpy(FLOATOPS, newFlops, sizeof(double) * NUM_KERNELS);
+
   return true; /* Options are valid */
 }
 

--- a/src/include/RaiderSTREAM/RSOpts.h
+++ b/src/include/RaiderSTREAM/RSOpts.h
@@ -239,65 +239,17 @@ public:
 ****************************************************/
   /**
    * @brief Maps the RS_KERNEL_TYPE enum to the amount of bytes being moved.
+   *
+   * Initialized only after RSOpts::parseOpts.
    */
-  double BYTES[NUM_KERNELS] = {
-		// Original Kernels
-		static_cast<double>(2 * sizeof(double) * streamArraySize), // Copy
-		static_cast<double>(2 * sizeof(double) * streamArraySize), // Scale
-		static_cast<double>(3 * sizeof(double) * streamArraySize), // Add
-		static_cast<double>(3 * sizeof(double) * streamArraySize), // Triad
-		// Gather Kernels
-		static_cast<double>(((2 * sizeof(double)) + (1 * sizeof(ssize_t))) * streamArraySize), // GATHER Copy
-		static_cast<double>(((2 * sizeof(double)) + (1 * sizeof(ssize_t))) * streamArraySize), // GATHER Scale
-		static_cast<double>(((3 * sizeof(double)) + (2 * sizeof(ssize_t))) * streamArraySize), // GATHER Add
-		static_cast<double>(((3 * sizeof(double)) + (2 * sizeof(ssize_t))) * streamArraySize), // GATHER Triad
-		// Scatter Kernels
-		static_cast<double>(((2 * sizeof(double)) + (1 * sizeof(ssize_t))) * streamArraySize), // SCATTER Copy
-		static_cast<double>(((2 * sizeof(double)) + (1 * sizeof(ssize_t))) * streamArraySize), // SCATTER Scale
-		static_cast<double>(((3 * sizeof(double)) + (1 * sizeof(ssize_t))) * streamArraySize), // SCATTER Add
-		static_cast<double>(((3 * sizeof(double)) + (1 * sizeof(ssize_t))) * streamArraySize), // SCATTER Triad
-		// Scatter-Gather Kernels
-		static_cast<double>(((2 * sizeof(double)) + (2 * sizeof(ssize_t))) * streamArraySize), // SG Copy
-		static_cast<double>(((2 * sizeof(double)) + (2 * sizeof(ssize_t))) * streamArraySize), // SG Scale
-		static_cast<double>(((3 * sizeof(double)) + (3 * sizeof(ssize_t))) * streamArraySize), // SG Add
-		static_cast<double>(((3 * sizeof(double)) + (3 * sizeof(ssize_t))) * streamArraySize), // SG Triad
-		// Central Kernels
-		static_cast<double>(2 * sizeof(double) * streamArraySize), // Central Copy
-		static_cast<double>(2 * sizeof(double) * streamArraySize), // Central Scale
-		static_cast<double>(3 * sizeof(double) * streamArraySize), // Central Add
-		static_cast<double>(3 * sizeof(double) * streamArraySize), // Central Triad
-  };
+  double BYTES[NUM_KERNELS];
 
   /**
    * @brief Maps the RS_KERNEL_TYPE enum to the float ops incurred.
+   *
+   * Initialized only after RSOpts::parseOpts.
    */
-  double FLOATOPS[NUM_KERNELS] = {
-		// Original Kernels
-		(double)0.0,                       // Copy
-		1.0 * streamArraySize,             // Scale
-		1.0 * streamArraySize,             // Add
-		2.0 * streamArraySize,             // Triad
-		// Gather Kernels
-		(double)0.0,                       // GATHER Copy
-		1.0 * streamArraySize,             // GATHER Scale
-		1.0 * streamArraySize,             // GATHER Add
-		2.0 * streamArraySize,             // GATHER Triad
-		// Scatter Kernels
-		(double)0.0,                       // SCATTER Copy
-		1.0 * streamArraySize,             // SCATTER Scale
-		1.0 * streamArraySize,             // SCATTER Add
-		2.0 * streamArraySize,             // SCATTER Triad
-		// Scatter-Gather Kernels
-		(double)0.0,                       // SG Copy
-		1.0 * streamArraySize,             // SG Scale
-		1.0 * streamArraySize,             // SG Add
-		2.0 * streamArraySize,             // SG Triad
-		// Central Kernels
-		(double)0.0,                       // CENTRAL Copy
-		1.0 * streamArraySize,             // CENTRAL Scale
-		1.0 * streamArraySize,             // CENTRAL Add
-		2.0 * streamArraySize,             // CENTRAL Triad
-  };
+  double FLOATOPS[NUM_KERNELS];
 
   /**
    * @brief Storage for the MBPS of benchmarks this invocation.

--- a/src/include/RaiderSTREAM/RSOpts.h
+++ b/src/include/RaiderSTREAM/RSOpts.h
@@ -242,14 +242,66 @@ public:
    *
    * Initialized only after RSOpts::parseOpts.
    */
-  double BYTES[NUM_KERNELS];
+  double BYTES[NUM_KERNELS] = {
+		// Original Kernels
+		static_cast<double>(2 * sizeof(double)), // Copy
+		static_cast<double>(2 * sizeof(double)), // Scale
+		static_cast<double>(3 * sizeof(double)), // Add
+		static_cast<double>(3 * sizeof(double)), // Triad
+		// Gather Kernels
+		static_cast<double>(((2 * sizeof(double)) + (1 * sizeof(ssize_t)))), // GATHER Copy
+		static_cast<double>(((2 * sizeof(double)) + (1 * sizeof(ssize_t)))), // GATHER Scale
+		static_cast<double>(((3 * sizeof(double)) + (2 * sizeof(ssize_t)))), // GATHER Add
+		static_cast<double>(((3 * sizeof(double)) + (2 * sizeof(ssize_t)))), // GATHER Triad
+		// Scatter Kernels
+		static_cast<double>(((2 * sizeof(double)) + (1 * sizeof(ssize_t)))), // SCATTER Copy
+		static_cast<double>(((2 * sizeof(double)) + (1 * sizeof(ssize_t)))), // SCATTER Scale
+		static_cast<double>(((3 * sizeof(double)) + (1 * sizeof(ssize_t)))), // SCATTER Add
+		static_cast<double>(((3 * sizeof(double)) + (1 * sizeof(ssize_t)))), // SCATTER Triad
+		// Scatter-Gather Kernels
+		static_cast<double>(((2 * sizeof(double)) + (2 * sizeof(ssize_t)))), // SG Copy
+		static_cast<double>(((2 * sizeof(double)) + (2 * sizeof(ssize_t)))), // SG Scale
+		static_cast<double>(((3 * sizeof(double)) + (3 * sizeof(ssize_t)))), // SG Add
+		static_cast<double>(((3 * sizeof(double)) + (3 * sizeof(ssize_t)))), // SG Triad
+		// Central Kernels
+		static_cast<double>(2 * sizeof(double)), // Central Copy
+		static_cast<double>(2 * sizeof(double)), // Central Scale
+		static_cast<double>(3 * sizeof(double)), // Central Add
+		static_cast<double>(3 * sizeof(double)), // Central Triad
+  };
 
   /**
    * @brief Maps the RS_KERNEL_TYPE enum to the float ops incurred.
    *
    * Initialized only after RSOpts::parseOpts.
    */
-  double FLOATOPS[NUM_KERNELS];
+  double FLOATOPS[NUM_KERNELS] = {
+		// Original Kernels
+		(double)0.0,                       // Copy
+		1.0,             // Scale
+		1.0,             // Add
+		2.0,             // Triad
+		// Gather Kernels
+		(double)0.0,                       // GATHER Copy
+		1.0,             // GATHER Scale
+		1.0,             // GATHER Add
+		2.0,             // GATHER Triad
+		// Scatter Kernels
+		(double)0.0,                       // SCATTER Copy
+		1.0,             // SCATTER Scale
+		1.0,             // SCATTER Add
+		2.0,             // SCATTER Triad
+		// Scatter-Gather Kernels
+		(double)0.0,                       // SG Copy
+		1.0,             // SG Scale
+		1.0,             // SG Add
+		2.0,             // SG Triad
+		// Central Kernels
+		(double)0.0,                       // CENTRAL Copy
+		1.0,             // CENTRAL Scale
+		1.0,             // CENTRAL Add
+		2.0,             // CENTRAL Triad
+  };
 
   /**
    * @brief Storage for the MBPS of benchmarks this invocation.


### PR DESCRIPTION
Previously, all MB/s and FLOPS computations used the static 1 million streamArraySize. Now, we figure that stuff out at runtime instead.

Fixes larger streamArraySize's appearing artificially slower in throughput than smaller sizes.